### PR TITLE
Close #42: ci: Harden firmware-build workflows and split release publishing into a least-privileged job

### DIFF
--- a/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
+++ b/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
@@ -65,21 +65,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -126,27 +126,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0
@@ -259,7 +259,11 @@ jobs:
           set -xeuo pipefail
           pwd
           if [[ "${TAG_ON_MASTER:-false}" == "true" ]]; then
-            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${TAG}"
+            # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize
+            # so the zip filename and uploaded asset name stay a single path
+            # component and the per-board/dev|prod naming scheme stays unique.
+            SAFE_TAG="${TAG//\//_}"
+            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${SAFE_TAG}"
           else
             ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}"
           fi
@@ -334,11 +338,20 @@ jobs:
 
           for rel in "${paths[@]}"; do
             src_path="$SRC/$rel"
+            if [ ! -f "$src_path" ]; then
+              echo "Missing release file: $src_path" >&2
+              exit 1
+            fi
             dst_path="$DST/$rel"
             mkdir -p "$(dirname "$dst_path")"
             cp "$src_path" "$dst_path"
           done
-          cp "${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
+          extra_src="${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml"
+          if [ ! -f "$extra_src" ]; then
+            echo "Missing release file: $extra_src" >&2
+            exit 1
+          fi
+          cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
           # Create zip file to upload as release asset
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
@@ -348,9 +361,15 @@ jobs:
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
+          # Use a name without .zip; GitHub adds .zip on download if the name
+          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
+          # file produced by "Create zip"); this keeps the Actions-page
+          # "Download artifact" UX identical to the original implementation
+          # -- the downloaded wrapper zip contains the directory directly,
+          # not an inner zip. The release job (below) re-creates the .zip
+          # from this same artifact, so no second upload of identical bytes
+          # is needed between jobs.
           name: ${{ steps.create_zip.outputs.artifact_name }}
-          # Upload whole directory with build artifacts
           path: ${{ steps.create_zip.outputs.artifact_name }}

--- a/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
+++ b/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
@@ -363,13 +363,7 @@ jobs:
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7
         with:
-          # Use a name without .zip; GitHub adds .zip on download if the name
-          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
-          # file produced by "Create zip"); this keeps the Actions-page
-          # "Download artifact" UX identical to the original implementation
-          # -- the downloaded wrapper zip contains the directory directly,
-          # not an inner zip. The release job (below) re-creates the .zip
-          # from this same artifact, so no second upload of identical bytes
-          # is needed between jobs.
+          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
           name: ${{ steps.create_zip.outputs.artifact_name }}
+          # Upload whole directory with build artifacts
           path: ${{ steps.create_zip.outputs.artifact_name }}

--- a/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
+++ b/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
@@ -260,8 +260,8 @@ jobs:
         run: |
           rm -rf "$RUNNER_TEMP/signing_keys"
 
-      - name: Create zip
-        id: create_zip
+      - name: Create release directory
+        id: create_zip   # kept for backwards-compat with `steps.create_zip.outputs.*` references
         env:
           TAG: ${{ github.ref_name }}
           TAG_ON_MASTER: ${{ steps.master_check.outputs.tag_on_master }}
@@ -364,12 +364,10 @@ jobs:
           fi
           cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
-          # Create zip file to upload as release asset
-          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
-          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
-
+          # The .zip file itself is created in the release job (see below)
+          # from the uploaded artifact, so the build job only exposes the
+          # directory's base name; no `artifact_path` output is needed here.
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
+++ b/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
@@ -51,7 +51,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
+++ b/.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
@@ -18,6 +18,17 @@ jobs:
     name: Build firmware (dev) for nRF52840DK RuuviAir-A2 release mock
     environment: dev
     runs-on: ubuntu-24.04
+    # Use the default GITHUB_TOKEN permissions for this job; release
+    # publishing happens in a separate, least-privileged job below.
+
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+      # Whether the pushed tag is on master; controls whether the release
+      # job runs.
+      tag_on_master: ${{ steps.master_check.outputs.tag_on_master }}
 
     strategy:
       matrix:
@@ -363,7 +374,69 @@ jobs:
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7
         with:
-          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
+          # Use a name without .zip; GitHub adds .zip on download if the name
+          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
+          # file produced by "Create zip"); this keeps the Actions-page
+          # "Download artifact" UX identical to the original implementation
+          # -- the downloaded wrapper zip contains the directory directly,
+          # not an inner zip. The release job (below) re-creates the .zip
+          # from this same artifact, so no second upload of identical bytes
+          # is needed between jobs.
           name: ${{ steps.create_zip.outputs.artifact_name }}
-          # Upload whole directory with build artifacts
           path: ${{ steps.create_zip.outputs.artifact_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.tag_on_master == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
+    steps:
+      - name: Download release directory artifact
+        uses: actions/download-artifact@v8
+        with:
+          # Reuses the permanent per-run artifact uploaded by the build job
+          # (no separate handoff artifact is created). The artifact contains
+          # the release DIRECTORY; the next step re-creates the same .zip
+          # the build job's "Create zip" step would have produced.
+          name: ${{ needs.build.outputs.release_zip_name }}
+          path: release_asset
+
+      - name: Create release and upload asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -xe
+          command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
+          # actions/download-artifact extracts the artifact contents into
+          # 'path:' preserving the in-artifact directory structure, so the
+          # per-run directory lands at release_asset/<ARTIFACT_NAME>/.
+          SRC_DIR="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}"
+          if [ ! -d "$SRC_DIR" ]; then
+            echo "Expected directory not found: $SRC_DIR" >&2
+            ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # Re-create the .zip locally; this matches what the build job's
+          # "Create zip" step produced, byte-content-wise.
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/${ARTIFACT_NAME}.zip"
+          ( cd "$GITHUB_WORKSPACE/release_asset" && zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME" )
+          # create if missing; on failure re-check to tolerate races with
+          # the other build-fw_* workflows that share the same tag.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
+              echo "Create failed; rechecking..."
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+                echo "Release still missing; aborting."
+                exit 1
+              fi
+            fi
+          fi
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw_ruuviair_a1-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a1-dev.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-fw_ruuviair_a1-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a1-dev.yml
@@ -18,8 +18,18 @@ jobs:
     name: Build firmware (dev) for RuuviAir-A1
     environment: dev
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write  # required to create GitHub Releases and upload assets
+    # Use the default GITHUB_TOKEN permissions for this job; release
+    # publishing happens in a separate, least-privileged job below.
+
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+      # Whether the pushed tag is on master; controls whether the release
+      # job runs (matches the gating previously used on the in-job
+      # "Create release and upload asset" step).
+      tag_on_master: ${{ steps.master_check.outputs.tag_on_master }}
 
     strategy:
       matrix:
@@ -67,21 +77,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -128,27 +138,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0
@@ -261,7 +271,11 @@ jobs:
           set -xeuo pipefail
           pwd
           if [[ "${TAG_ON_MASTER:-false}" == "true" ]]; then
-            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${TAG}"
+            # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize
+            # so the zip filename and uploaded asset name stay a single path
+            # component and the per-board/dev|prod naming scheme stays unique.
+            SAFE_TAG="${TAG//\//_}"
+            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${SAFE_TAG}"
           else
             ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}"
           fi
@@ -336,11 +350,20 @@ jobs:
 
           for rel in "${paths[@]}"; do
             src_path="$SRC/$rel"
+            if [ ! -f "$src_path" ]; then
+              echo "Missing release file: $src_path" >&2
+              exit 1
+            fi
             dst_path="$DST/$rel"
             mkdir -p "$(dirname "$dst_path")"
             cp "$src_path" "$dst_path"
           done
-          cp "${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
+          extra_src="${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml"
+          if [ ! -f "$extra_src" ]; then
+            echo "Missing release file: $extra_src" >&2
+            exit 1
+          fi
+          cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
           # Create zip file to upload as release asset
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
@@ -349,33 +372,72 @@ jobs:
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
+      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
+        uses: actions/upload-artifact@v7
+        with:
+          # Use a name without .zip; GitHub adds .zip on download if the name
+          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
+          # file produced by "Create zip"); this keeps the Actions-page
+          # "Download artifact" UX identical to the original implementation
+          # -- the downloaded wrapper zip contains the directory directly,
+          # not an inner zip. The release job (below) re-creates the .zip
+          # from this same artifact, so no second upload of identical bytes
+          # is needed between jobs.
+          name: ${{ steps.create_zip.outputs.artifact_name }}
+          path: ${{ steps.create_zip.outputs.artifact_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.tag_on_master == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
+    steps:
+      - name: Download release directory artifact
+        uses: actions/download-artifact@v8
+        with:
+          # Reuses the permanent per-run artifact uploaded by the build job
+          # (no separate handoff artifact is created). The artifact contains
+          # the release DIRECTORY; the next step re-creates the same .zip
+          # the build job's "Create zip" step would have produced.
+          name: ${{ needs.build.outputs.release_zip_name }}
+          path: release_asset
+
       - name: Create release and upload asset
-        if: startsWith(github.ref, 'refs/tags/') && steps.master_check.outputs.tag_on_master == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
         shell: bash
-        working-directory: ${{ env.PROJECT_DIR }}
         run: |
           set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          # create if missing; on failure re-check to tolerate races
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+          # actions/download-artifact extracts the artifact contents into
+          # 'path:' preserving the in-artifact directory structure, so the
+          # per-run directory lands at release_asset/<ARTIFACT_NAME>/.
+          SRC_DIR="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}"
+          if [ ! -d "$SRC_DIR" ]; then
+            echo "Expected directory not found: $SRC_DIR" >&2
+            ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # Re-create the .zip locally; this matches what the build job's
+          # "Create zip" step produced, byte-content-wise.
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/${ARTIFACT_NAME}.zip"
+          ( cd "$GITHUB_WORKSPACE/release_asset" && zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME" )
+          # create if missing; on failure re-check to tolerate races with
+          # the other build-fw_ruuviair_* workflows that share the same tag.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
               echo "Create failed; rechecking..."
-              if ! gh release view "$TAG" >/dev/null 2>&1; then
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "Release still missing; aborting."
                 exit 1
               fi
             fi
           fi
-          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber
-
-      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
-        uses: actions/upload-artifact@v4
-        with:
-          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
-          name: ${{ steps.create_zip.outputs.artifact_name }}
-          # Upload whole directory with build artifacts
-          path: ${{ steps.create_zip.outputs.artifact_name }}
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw_ruuviair_a1-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a1-dev.yml
@@ -261,8 +261,8 @@ jobs:
         run: |
           rm -rf "$RUNNER_TEMP/signing_keys"
 
-      - name: Create zip
-        id: create_zip
+      - name: Create release directory
+        id: create_zip   # kept for backwards-compat with `steps.create_zip.outputs.*` references
         env:
           TAG: ${{ github.ref_name }}
           TAG_ON_MASTER: ${{ steps.master_check.outputs.tag_on_master }}
@@ -365,12 +365,10 @@ jobs:
           fi
           cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
-          # Create zip file to upload as release asset
-          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
-          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
-
+          # The .zip file itself is created in the release job (see below)
+          # from the uploaded artifact, so the build job only exposes the
+          # directory's base name; no `artifact_path` output is needed here.
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-fw_ruuviair_a2-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a2-dev.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-fw_ruuviair_a2-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a2-dev.yml
@@ -261,8 +261,8 @@ jobs:
         run: |
           rm -rf "$RUNNER_TEMP/signing_keys"
 
-      - name: Create zip
-        id: create_zip
+      - name: Create release directory
+        id: create_zip   # kept for backwards-compat with `steps.create_zip.outputs.*` references
         env:
           TAG: ${{ github.ref_name }}
           TAG_ON_MASTER: ${{ steps.master_check.outputs.tag_on_master }}
@@ -365,12 +365,10 @@ jobs:
           fi
           cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
-          # Create zip file to upload as release asset
-          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
-          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
-
+          # The .zip file itself is created in the release job (see below)
+          # from the uploaded artifact, so the build job only exposes the
+          # directory's base name; no `artifact_path` output is needed here.
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-fw_ruuviair_a2-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a2-dev.yml
@@ -18,8 +18,18 @@ jobs:
     name: Build firmware (dev) for RuuviAir-A2
     environment: dev
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write  # required to create GitHub Releases and upload assets
+    # Use the default GITHUB_TOKEN permissions for this job; release
+    # publishing happens in a separate, least-privileged job below.
+
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+      # Whether the pushed tag is on master; controls whether the release
+      # job runs (matches the gating previously used on the in-job
+      # "Create release and upload asset" step).
+      tag_on_master: ${{ steps.master_check.outputs.tag_on_master }}
 
     strategy:
       matrix:
@@ -67,21 +77,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -128,27 +138,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0
@@ -261,7 +271,11 @@ jobs:
           set -xeuo pipefail
           pwd
           if [[ "${TAG_ON_MASTER:-false}" == "true" ]]; then
-            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${TAG}"
+            # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize
+            # so the zip filename and uploaded asset name stay a single path
+            # component and the per-board/dev|prod naming scheme stays unique.
+            SAFE_TAG="${TAG//\//_}"
+            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${SAFE_TAG}"
           else
             ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}"
           fi
@@ -336,11 +350,20 @@ jobs:
 
           for rel in "${paths[@]}"; do
             src_path="$SRC/$rel"
+            if [ ! -f "$src_path" ]; then
+              echo "Missing release file: $src_path" >&2
+              exit 1
+            fi
             dst_path="$DST/$rel"
             mkdir -p "$(dirname "$dst_path")"
             cp "$src_path" "$dst_path"
           done
-          cp "${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
+          extra_src="${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml"
+          if [ ! -f "$extra_src" ]; then
+            echo "Missing release file: $extra_src" >&2
+            exit 1
+          fi
+          cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
           # Create zip file to upload as release asset
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
@@ -349,33 +372,72 @@ jobs:
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
+      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
+        uses: actions/upload-artifact@v7
+        with:
+          # Use a name without .zip; GitHub adds .zip on download if the name
+          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
+          # file produced by "Create zip"); this keeps the Actions-page
+          # "Download artifact" UX identical to the original implementation
+          # -- the downloaded wrapper zip contains the directory directly,
+          # not an inner zip. The release job (below) re-creates the .zip
+          # from this same artifact, so no second upload of identical bytes
+          # is needed between jobs.
+          name: ${{ steps.create_zip.outputs.artifact_name }}
+          path: ${{ steps.create_zip.outputs.artifact_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.tag_on_master == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
+    steps:
+      - name: Download release directory artifact
+        uses: actions/download-artifact@v8
+        with:
+          # Reuses the permanent per-run artifact uploaded by the build job
+          # (no separate handoff artifact is created). The artifact contains
+          # the release DIRECTORY; the next step re-creates the same .zip
+          # the build job's "Create zip" step would have produced.
+          name: ${{ needs.build.outputs.release_zip_name }}
+          path: release_asset
+
       - name: Create release and upload asset
-        if: startsWith(github.ref, 'refs/tags/') && steps.master_check.outputs.tag_on_master == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
         shell: bash
-        working-directory: ${{ env.PROJECT_DIR }}
         run: |
           set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          # create if missing; on failure re-check to tolerate races
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+          # actions/download-artifact extracts the artifact contents into
+          # 'path:' preserving the in-artifact directory structure, so the
+          # per-run directory lands at release_asset/<ARTIFACT_NAME>/.
+          SRC_DIR="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}"
+          if [ ! -d "$SRC_DIR" ]; then
+            echo "Expected directory not found: $SRC_DIR" >&2
+            ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # Re-create the .zip locally; this matches what the build job's
+          # "Create zip" step produced, byte-content-wise.
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/${ARTIFACT_NAME}.zip"
+          ( cd "$GITHUB_WORKSPACE/release_asset" && zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME" )
+          # create if missing; on failure re-check to tolerate races with
+          # the other build-fw_ruuviair_* workflows that share the same tag.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
               echo "Create failed; rechecking..."
-              if ! gh release view "$TAG" >/dev/null 2>&1; then
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "Release still missing; aborting."
                 exit 1
               fi
             fi
           fi
-          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber
-
-      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
-        uses: actions/upload-artifact@v4
-        with:
-          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
-          name: ${{ steps.create_zip.outputs.artifact_name }}
-          # Upload whole directory with build artifacts
-          path: ${{ steps.create_zip.outputs.artifact_name }}
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw_ruuviair_a2-prod.yml
+++ b/.github/workflows/build-fw_ruuviair_a2-prod.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-fw_ruuviair_a2-prod.yml
+++ b/.github/workflows/build-fw_ruuviair_a2-prod.yml
@@ -258,8 +258,8 @@ jobs:
         run: |
           rm -rf "$RUNNER_TEMP/signing_keys"
 
-      - name: Create zip
-        id: create_zip
+      - name: Create release directory
+        id: create_zip   # kept for backwards-compat with `steps.create_zip.outputs.*` references
         env:
           TAG: ${{ github.ref_name }}
           TAG_ON_MASTER: ${{ steps.master_check.outputs.tag_on_master }}
@@ -362,12 +362,10 @@ jobs:
           fi
           cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
-          # Create zip file to upload as release asset
-          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
-          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
-
+          # The .zip file itself is created in the release job (see below)
+          # from the uploaded artifact, so the build job only exposes the
+          # directory's base name; no `artifact_path` output is needed here.
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-fw_ruuviair_a2-prod.yml
+++ b/.github/workflows/build-fw_ruuviair_a2-prod.yml
@@ -15,8 +15,18 @@ jobs:
     name: Build firmware (prod) for RuuviAir-A2
     environment: prod
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write  # required to create GitHub Releases and upload assets
+    # Use the default GITHUB_TOKEN permissions for this job; release
+    # publishing happens in a separate, least-privileged job below.
+
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+      # Whether the pushed tag is on master; controls whether the release
+      # job runs (matches the gating previously used on the in-job
+      # "Create release and upload asset" step).
+      tag_on_master: ${{ steps.master_check.outputs.tag_on_master }}
 
     strategy:
       matrix:
@@ -64,21 +74,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -125,27 +135,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0
@@ -258,7 +268,11 @@ jobs:
           set -xeuo pipefail
           pwd
           if [[ "${TAG_ON_MASTER:-false}" == "true" ]]; then
-            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${TAG}"
+            # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize
+            # so the zip filename and uploaded asset name stay a single path
+            # component and the per-board/dev|prod naming scheme stays unique.
+            SAFE_TAG="${TAG//\//_}"
+            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${SAFE_TAG}"
           else
             ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}"
           fi
@@ -333,11 +347,20 @@ jobs:
 
           for rel in "${paths[@]}"; do
             src_path="$SRC/$rel"
+            if [ ! -f "$src_path" ]; then
+              echo "Missing release file: $src_path" >&2
+              exit 1
+            fi
             dst_path="$DST/$rel"
             mkdir -p "$(dirname "$dst_path")"
             cp "$src_path" "$dst_path"
           done
-          cp "${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
+          extra_src="${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml"
+          if [ ! -f "$extra_src" ]; then
+            echo "Missing release file: $extra_src" >&2
+            exit 1
+          fi
+          cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
           # Create zip file to upload as release asset
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
@@ -346,33 +369,72 @@ jobs:
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
+      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
+        uses: actions/upload-artifact@v7
+        with:
+          # Use a name without .zip; GitHub adds .zip on download if the name
+          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
+          # file produced by "Create zip"); this keeps the Actions-page
+          # "Download artifact" UX identical to the original implementation
+          # -- the downloaded wrapper zip contains the directory directly,
+          # not an inner zip. The release job (below) re-creates the .zip
+          # from this same artifact, so no second upload of identical bytes
+          # is needed between jobs.
+          name: ${{ steps.create_zip.outputs.artifact_name }}
+          path: ${{ steps.create_zip.outputs.artifact_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.tag_on_master == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
+    steps:
+      - name: Download release directory artifact
+        uses: actions/download-artifact@v8
+        with:
+          # Reuses the permanent per-run artifact uploaded by the build job
+          # (no separate handoff artifact is created). The artifact contains
+          # the release DIRECTORY; the next step re-creates the same .zip
+          # the build job's "Create zip" step would have produced.
+          name: ${{ needs.build.outputs.release_zip_name }}
+          path: release_asset
+
       - name: Create release and upload asset
-        if: startsWith(github.ref, 'refs/tags/') && steps.master_check.outputs.tag_on_master == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
         shell: bash
-        working-directory: ${{ env.PROJECT_DIR }}
         run: |
           set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          # create if missing; on failure re-check to tolerate races
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+          # actions/download-artifact extracts the artifact contents into
+          # 'path:' preserving the in-artifact directory structure, so the
+          # per-run directory lands at release_asset/<ARTIFACT_NAME>/.
+          SRC_DIR="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}"
+          if [ ! -d "$SRC_DIR" ]; then
+            echo "Expected directory not found: $SRC_DIR" >&2
+            ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # Re-create the .zip locally; this matches what the build job's
+          # "Create zip" step produced, byte-content-wise.
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/${ARTIFACT_NAME}.zip"
+          ( cd "$GITHUB_WORKSPACE/release_asset" && zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME" )
+          # create if missing; on failure re-check to tolerate races with
+          # the other build-fw_ruuviair_* workflows that share the same tag.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
               echo "Create failed; rechecking..."
-              if ! gh release view "$TAG" >/dev/null 2>&1; then
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "Release still missing; aborting."
                 exit 1
               fi
             fi
           fi
-          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber
-
-      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
-        uses: actions/upload-artifact@v4
-        with:
-          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
-          name: ${{ steps.create_zip.outputs.artifact_name }}
-          # Upload whole directory with build artifacts
-          path: ${{ steps.create_zip.outputs.artifact_name }}
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw_ruuviair_a3-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a3-dev.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-fw_ruuviair_a3-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a3-dev.yml
@@ -261,8 +261,8 @@ jobs:
         run: |
           rm -rf "$RUNNER_TEMP/signing_keys"
 
-      - name: Create zip
-        id: create_zip
+      - name: Create release directory
+        id: create_zip   # kept for backwards-compat with `steps.create_zip.outputs.*` references
         env:
           TAG: ${{ github.ref_name }}
           TAG_ON_MASTER: ${{ steps.master_check.outputs.tag_on_master }}
@@ -365,12 +365,10 @@ jobs:
           fi
           cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
-          # Create zip file to upload as release asset
-          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
-          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
-
+          # The .zip file itself is created in the release job (see below)
+          # from the uploaded artifact, so the build job only exposes the
+          # directory's base name; no `artifact_path` output is needed here.
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-fw_ruuviair_a3-dev.yml
+++ b/.github/workflows/build-fw_ruuviair_a3-dev.yml
@@ -18,8 +18,18 @@ jobs:
     name: Build firmware (dev) for RuuviAir-A3
     environment: dev
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write  # required to create GitHub Releases and upload assets
+    # Use the default GITHUB_TOKEN permissions for this job; release
+    # publishing happens in a separate, least-privileged job below.
+
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+      # Whether the pushed tag is on master; controls whether the release
+      # job runs (matches the gating previously used on the in-job
+      # "Create release and upload asset" step).
+      tag_on_master: ${{ steps.master_check.outputs.tag_on_master }}
 
     strategy:
       matrix:
@@ -67,21 +77,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -128,27 +138,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0
@@ -261,7 +271,11 @@ jobs:
           set -xeuo pipefail
           pwd
           if [[ "${TAG_ON_MASTER:-false}" == "true" ]]; then
-            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${TAG}"
+            # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize
+            # so the zip filename and uploaded asset name stay a single path
+            # component and the per-board/dev|prod naming scheme stays unique.
+            SAFE_TAG="${TAG//\//_}"
+            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${SAFE_TAG}"
           else
             ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}"
           fi
@@ -336,11 +350,20 @@ jobs:
 
           for rel in "${paths[@]}"; do
             src_path="$SRC/$rel"
+            if [ ! -f "$src_path" ]; then
+              echo "Missing release file: $src_path" >&2
+              exit 1
+            fi
             dst_path="$DST/$rel"
             mkdir -p "$(dirname "$dst_path")"
             cp "$src_path" "$dst_path"
           done
-          cp "${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
+          extra_src="${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml"
+          if [ ! -f "$extra_src" ]; then
+            echo "Missing release file: $extra_src" >&2
+            exit 1
+          fi
+          cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
           # Create zip file to upload as release asset
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
@@ -349,33 +372,72 @@ jobs:
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
+      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
+        uses: actions/upload-artifact@v7
+        with:
+          # Use a name without .zip; GitHub adds .zip on download if the name
+          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
+          # file produced by "Create zip"); this keeps the Actions-page
+          # "Download artifact" UX identical to the original implementation
+          # -- the downloaded wrapper zip contains the directory directly,
+          # not an inner zip. The release job (below) re-creates the .zip
+          # from this same artifact, so no second upload of identical bytes
+          # is needed between jobs.
+          name: ${{ steps.create_zip.outputs.artifact_name }}
+          path: ${{ steps.create_zip.outputs.artifact_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.tag_on_master == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
+    steps:
+      - name: Download release directory artifact
+        uses: actions/download-artifact@v8
+        with:
+          # Reuses the permanent per-run artifact uploaded by the build job
+          # (no separate handoff artifact is created). The artifact contains
+          # the release DIRECTORY; the next step re-creates the same .zip
+          # the build job's "Create zip" step would have produced.
+          name: ${{ needs.build.outputs.release_zip_name }}
+          path: release_asset
+
       - name: Create release and upload asset
-        if: startsWith(github.ref, 'refs/tags/') && steps.master_check.outputs.tag_on_master == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
         shell: bash
-        working-directory: ${{ env.PROJECT_DIR }}
         run: |
           set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          # create if missing; on failure re-check to tolerate races
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+          # actions/download-artifact extracts the artifact contents into
+          # 'path:' preserving the in-artifact directory structure, so the
+          # per-run directory lands at release_asset/<ARTIFACT_NAME>/.
+          SRC_DIR="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}"
+          if [ ! -d "$SRC_DIR" ]; then
+            echo "Expected directory not found: $SRC_DIR" >&2
+            ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # Re-create the .zip locally; this matches what the build job's
+          # "Create zip" step produced, byte-content-wise.
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/${ARTIFACT_NAME}.zip"
+          ( cd "$GITHUB_WORKSPACE/release_asset" && zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME" )
+          # create if missing; on failure re-check to tolerate races with
+          # the other build-fw_ruuviair_* workflows that share the same tag.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
               echo "Create failed; rechecking..."
-              if ! gh release view "$TAG" >/dev/null 2>&1; then
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "Release still missing; aborting."
                 exit 1
               fi
             fi
           fi
-          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber
-
-      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
-        uses: actions/upload-artifact@v4
-        with:
-          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
-          name: ${{ steps.create_zip.outputs.artifact_name }}
-          # Upload whole directory with build artifacts
-          path: ${{ steps.create_zip.outputs.artifact_name }}
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw_ruuviair_a3-prod.yml
+++ b/.github/workflows/build-fw_ruuviair_a3-prod.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-fw_ruuviair_a3-prod.yml
+++ b/.github/workflows/build-fw_ruuviair_a3-prod.yml
@@ -258,8 +258,8 @@ jobs:
         run: |
           rm -rf "$RUNNER_TEMP/signing_keys"
 
-      - name: Create zip
-        id: create_zip
+      - name: Create release directory
+        id: create_zip   # kept for backwards-compat with `steps.create_zip.outputs.*` references
         env:
           TAG: ${{ github.ref_name }}
           TAG_ON_MASTER: ${{ steps.master_check.outputs.tag_on_master }}
@@ -362,12 +362,10 @@ jobs:
           fi
           cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
-          # Create zip file to upload as release asset
-          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
-          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
-
+          # The .zip file itself is created in the release job (see below)
+          # from the uploaded artifact, so the build job only exposes the
+          # directory's base name; no `artifact_path` output is needed here.
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-fw_ruuviair_a3-prod.yml
+++ b/.github/workflows/build-fw_ruuviair_a3-prod.yml
@@ -15,8 +15,18 @@ jobs:
     name: Build firmware (prod) for RuuviAir-A3
     environment: prod
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write  # required to create GitHub Releases and upload assets
+    # Use the default GITHUB_TOKEN permissions for this job; release
+    # publishing happens in a separate, least-privileged job below.
+
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+      # Whether the pushed tag is on master; controls whether the release
+      # job runs (matches the gating previously used on the in-job
+      # "Create release and upload asset" step).
+      tag_on_master: ${{ steps.master_check.outputs.tag_on_master }}
 
     strategy:
       matrix:
@@ -64,21 +74,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -125,27 +135,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0
@@ -258,7 +268,11 @@ jobs:
           set -xeuo pipefail
           pwd
           if [[ "${TAG_ON_MASTER:-false}" == "true" ]]; then
-            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${TAG}"
+            # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize
+            # so the zip filename and uploaded asset name stay a single path
+            # component and the per-board/dev|prod naming scheme stays unique.
+            SAFE_TAG="${TAG//\//_}"
+            ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}_${SAFE_TAG}"
           else
             ARTIFACT_NAME="${{ env.BUILD_DIR_NAME }}"
           fi
@@ -333,11 +347,20 @@ jobs:
 
           for rel in "${paths[@]}"; do
             src_path="$SRC/$rel"
+            if [ ! -f "$src_path" ]; then
+              echo "Missing release file: $src_path" >&2
+              exit 1
+            fi
             dst_path="$DST/$rel"
             mkdir -p "$(dirname "$dst_path")"
             cp "$src_path" "$dst_path"
           done
-          cp "${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
+          extra_src="${{ env.PROJECT_DIR }}/nrfjprog_cfg_ruuviair.toml"
+          if [ ! -f "$extra_src" ]; then
+            echo "Missing release file: $extra_src" >&2
+            exit 1
+          fi
+          cp "$extra_src" "$ARTIFACT_NAME/nrfjprog_cfg_ruuviair.toml"
 
           # Create zip file to upload as release asset
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
@@ -346,33 +369,72 @@ jobs:
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
+      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
+        uses: actions/upload-artifact@v7
+        with:
+          # Use a name without .zip; GitHub adds .zip on download if the name
+          # ends with .zip. Upload the per-run release DIRECTORY (not the .zip
+          # file produced by "Create zip"); this keeps the Actions-page
+          # "Download artifact" UX identical to the original implementation
+          # -- the downloaded wrapper zip contains the directory directly,
+          # not an inner zip. The release job (below) re-creates the .zip
+          # from this same artifact, so no second upload of identical bytes
+          # is needed between jobs.
+          name: ${{ steps.create_zip.outputs.artifact_name }}
+          path: ${{ steps.create_zip.outputs.artifact_name }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.tag_on_master == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
+    steps:
+      - name: Download release directory artifact
+        uses: actions/download-artifact@v8
+        with:
+          # Reuses the permanent per-run artifact uploaded by the build job
+          # (no separate handoff artifact is created). The artifact contains
+          # the release DIRECTORY; the next step re-creates the same .zip
+          # the build job's "Create zip" step would have produced.
+          name: ${{ needs.build.outputs.release_zip_name }}
+          path: release_asset
+
       - name: Create release and upload asset
-        if: startsWith(github.ref, 'refs/tags/') && steps.master_check.outputs.tag_on_master == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
         shell: bash
-        working-directory: ${{ env.PROJECT_DIR }}
         run: |
           set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          # create if missing; on failure re-check to tolerate races
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+          # actions/download-artifact extracts the artifact contents into
+          # 'path:' preserving the in-artifact directory structure, so the
+          # per-run directory lands at release_asset/<ARTIFACT_NAME>/.
+          SRC_DIR="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}"
+          if [ ! -d "$SRC_DIR" ]; then
+            echo "Expected directory not found: $SRC_DIR" >&2
+            ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # Re-create the .zip locally; this matches what the build job's
+          # "Create zip" step produced, byte-content-wise.
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/${ARTIFACT_NAME}.zip"
+          ( cd "$GITHUB_WORKSPACE/release_asset" && zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME" )
+          # create if missing; on failure re-check to tolerate races with
+          # the other build-fw_ruuviair_* workflows that share the same tag.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
               echo "Create failed; rechecking..."
-              if ! gh release view "$TAG" >/dev/null 2>&1; then
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "Release still missing; aborting."
                 exit 1
               fi
             fi
           fi
-          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber
-
-      - name: Upload artifact ${{ steps.create_zip.outputs.artifact_name }}
-        uses: actions/upload-artifact@v4
-        with:
-          # Use a name without .zip; GitHub adds .zip on download if the name ends with .zip
-          name: ${{ steps.create_zip.outputs.artifact_name }}
-          # Upload whole directory with build artifacts
-          path: ${{ steps.create_zip.outputs.artifact_name }}
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-ruuvi_air_rgb_ctrl.yml
+++ b/.github/workflows/build-ruuvi_air_rgb_ctrl.yml
@@ -63,21 +63,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -124,27 +124,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4     # Checks-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6     # Checks-out repository under $GITHUB_WORKSPACE
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
@@ -200,7 +200,7 @@ jobs:
           mv "$HOME/ncs/${{ env.NCS_VERSION }}/${{ env.PROJECT_DIR }}" "$GITHUB_WORKSPACE/${PROJECT_DIR}"
 
       - name: Upload artifact ruuvi_air_rgb_ctrl
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ruuvi_air_rgb_ctrl
           path: |

--- a/.github/workflows/build-ruuvi_air_rgb_ctrl.yml
+++ b/.github/workflows/build-ruuvi_air_rgb_ctrl.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -63,21 +63,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -124,27 +124,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4     # Checks-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6     # Checks-out repository under $GITHUB_WORKSPACE
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # No submodules required for Dockerfile-only builds; set true if needed
           fetch-depth: 0

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -64,21 +64,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -125,21 +125,21 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
@@ -167,7 +167,7 @@ jobs:
           ls -la $HOME/bin/sonar-scanner/bin
 
       - name: Checkout the code
-        uses: actions/checkout@v4     # Checks-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6     # Checks-out repository under $GITHUB_WORKSPACE
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/unit-tests-native_sim.yml
+++ b/.github/workflows/unit-tests-native_sim.yml
@@ -63,21 +63,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -124,27 +124,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4     # Checks-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6     # Checks-out repository under $GITHUB_WORKSPACE
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/unit-tests-native_sim.yml
+++ b/.github/workflows/unit-tests-native_sim.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/unit-tests-native_sim64.yml
+++ b/.github/workflows/unit-tests-native_sim64.yml
@@ -63,21 +63,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -124,27 +124,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4     # Checks-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6     # Checks-out repository under $GITHUB_WORKSPACE
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/unit-tests-native_sim64.yml
+++ b/.github/workflows/unit-tests-native_sim64.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/unit-tests-nrf52840dk.yml
+++ b/.github/workflows/unit-tests-nrf52840dk.yml
@@ -63,21 +63,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -124,27 +124,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4     # Checks-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6     # Checks-out repository under $GITHUB_WORKSPACE
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/unit-tests-nrf52840dk.yml
+++ b/.github/workflows/unit-tests-nrf52840dk.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/unit-tests-ruuvi_air.yml
+++ b/.github/workflows/unit-tests-ruuvi_air.yml
@@ -63,21 +63,21 @@ jobs:
 
       - name: Restore cached 'nrfutil Toolchain Manager'
         id: cache-nrfutil-tcm
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.nrfutil
           key: nrfutil-tcm-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect toolchains'
         id: cache-ncs-toolchains
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/toolchains
           key: ncs-toolchains-${{ env.NCS_VERSION }}-v4
 
       - name: Restore cached 'nRF Connect SDK ${{ env.NCS_VERSION }}'
         id: cache-ncs-sdk
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ncs-sdk-${{ env.NCS_VERSION }}-v4
@@ -124,27 +124,27 @@ jobs:
             '
       - name: Save 'nrfutil Toolchain Manager'
         if: ${{ steps.cache-nrfutil-tcm.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.nrfutil
           key: ${{ steps.cache-nrfutil-tcm.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect toolchains' cache (only on miss)
         if: ${{ steps.cache-ncs-toolchains.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/toolchains
           key: ${{ steps.cache-ncs-toolchains.outputs.cache-primary-key }}
 
       - name: Save 'nRF Connect SDK' cache (only on miss)
         if: ${{ steps.cache-ncs-sdk.outputs.cache-hit != 'true' && !cancelled() }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ncs/${{ env.NCS_VERSION }}
           key: ${{ steps.cache-ncs-sdk.outputs.cache-primary-key }}
 
       - name: Checkout the code
-        uses: actions/checkout@v4     # Checks-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6     # Checks-out repository under $GITHUB_WORKSPACE
         with:
           path: ${{ env.PROJECT_DIR }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/unit-tests-ruuvi_air.yml
+++ b/.github/workflows/unit-tests-ruuvi_air.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Log in to GHCR. This can be removed if the image is public.
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## What this PR does

Backports the security and robustness improvements made on the
[`ruuvi.gateway_esp.c#1281`](https://github.com/ruuvi/ruuvi.gateway_esp.c/issues/1281)
branch (commits `09309fe9..19ef5162`) to the firmware-build workflows
in this repository, and bumps every JavaScript-based action across
all CI workflows to a version that runs on the Node.js 24 runtime.

### Workflows that received the full hardening (build/release split + zip-handling fixes + version bumps)

```
.github/workflows/build-fw_nrf52840dk_a2_release_mock.yml
.github/workflows/build-fw_ruuviair_a1-dev.yml
.github/workflows/build-fw_ruuviair_a2-dev.yml
.github/workflows/build-fw_ruuviair_a2-prod.yml
.github/workflows/build-fw_ruuviair_a3-dev.yml
.github/workflows/build-fw_ruuviair_a3-prod.yml
```

All six were structurally aligned after this PR: each has a `build`
job that runs with default `GITHUB_TOKEN` permissions and uploads a
single per-run artifact (the release directory), plus a separate
`release` job (gated on tag-on-master, scoped to
`{contents: write, actions: read}`) that downloads that artifact,
re-zips it locally, and publishes it as a GitHub Release asset.

> Note: the `build-fw_nrf52840dk_a2_release_mock.yml` workflow
> historically did not publish a GitHub Release. The
> build/release-job split was added in a follow-up commit on this
> branch so it matches the same hardening pattern as the
> `build-fw_ruuviair_*.yml` workflows. On a tag-on-master push it
> now contributes one additional asset to the Release named
> `build_nrf52840dk_a2_release_mock-dev_<tag>.zip` (clearly
> distinguishable from production assets by the `release_mock`
> substring).

### Workflows that received only the action-version bumps

```
.github/workflows/build-ruuvi_air_rgb_ctrl.yml
.github/workflows/code-style.yml
.github/workflows/docker-publish.yml
.github/workflows/sonar-scan.yml
.github/workflows/unit-tests-native_sim.yml
.github/workflows/unit-tests-native_sim64.yml
.github/workflows/unit-tests-nrf52840dk.yml
.github/workflows/unit-tests-ruuvi_air.yml
```

These workflows do not publish GitHub Releases, so the build/release
split does not apply to them; the version bumps alone are enough to
clear the Node.js 20 deprecation warnings.

## Changes

### 1. Split publishing into a separate, least-privileged `release` job

The `build` job no longer declares `permissions:` at all and so runs
with the default `GITHUB_TOKEN` scope for every event (push,
`pull_request`, tag). All Release-publishing work moves to a new
top-level `release` job:

```yaml
release:
  needs: build
  if: startsWith(github.ref, 'refs/tags/')
       && needs.build.outputs.tag_on_master == 'true'
  runs-on: ubuntu-24.04
  permissions:
    contents: write   # create GitHub Release and upload assets
    actions: read     # download workflow artifact from the build job
```

The release job contains no project / third-party build code; it only
downloads the build job's artifact, re-zips locally, and runs
`gh release create / upload`. Because `permissions:` declared on a job
sets every unlisted scope to `none`, `actions: read` is added
explicitly so `actions/download-artifact` can fetch the build job's
artifact.

The existing "tag must be on master" gate is preserved by exposing
`steps.master_check.outputs.tag_on_master` as a `build` job output and
consuming it from the release job's `if:` expression.

### 2. Sanitize `TAG` for filenames

`github.ref_name` may contain `/` (e.g. `release/v1.2.3`). The
`Create zip` step now does:

```bash
SAFE_TAG="${TAG//\//_}"
ARTIFACT_NAME="${BUILD_DIR_NAME}_${SAFE_TAG}"
```

The sanitized name is exposed via `jobs.build.outputs.release_zip_name`
so the release job can locate the downloaded artifact without
re-implementing the sanitization (and without using the `replace()`
expression function, which does not exist at the top level of the
GitHub Actions expression language).

The git tag itself (`$TAG`) is left unsanitized in
`gh release create/view/upload` because it must match the actual ref
pushed to the repository.

### 3. Reuse the single permanent artifact across jobs

The build job uploads **exactly one** workflow artifact -- the per-run
release **directory** -- with `actions/upload-artifact@v7` and
`if-no-files-found: error`. No temporary handoff artifact is created.

The release job downloads that same artifact via
`actions/download-artifact@v8`, which extracts its contents into
`release_asset/<ARTIFACT_NAME>/`. It then recreates the release `.zip`
locally with `( cd release_asset && zip -r -q ... )` -- byte-content
equivalent to the zip the build job's `Create zip` step produces --
and uploads it to the GitHub Release.

**Why upload the directory and not the `.zip` file?** GitHub's
Actions-page "Download artifact" button always wraps the artifact
contents in a fresh zip. Uploading the `.zip` file as the artifact
would therefore produce a *double-zip* on UI download
(wrapper.zip -> inner.zip), regressing the existing UX. Uploading the
directory keeps the UI download identical to the original behavior
(a single zip whose top-level entry is the per-run directory). The
release-job re-zip step costs well under a second on every tag build.

### 4. Race-tolerant Release creation across concurrent workflows

The six firmware-build workflows all trigger on the same tag push, so
they race to create the GitHub Release. The release job's
create-or-upload script keeps the same view-then-create-then-recheck
pattern the original in-job step used, but now scopes every `gh` call
with `--repo "$GITHUB_REPOSITORY"` because the release job performs
no `actions/checkout`.

### 5. Clearer "missing release file" diagnostic

The `Create zip` step's `cp` loop now explicitly checks each source
path:

```bash
for rel in "${paths[@]}"; do
  src_path="$SRC/$rel"
  if [ ! -f "$src_path" ]; then
    echo "Missing release file: $src_path" >&2
    exit 1
  fi
  ...
done
```

The same check is applied to the extra `nrfjprog_cfg_ruuviair.toml`
copy. No behavior change beyond a clearly-prefixed, single-line
failure naming the missing path instead of a bare `cp: cannot stat
'<path>': No such file or directory`.

### 6. Action versions bumped to Node.js 24 runtimes

Applied across **all 14 workflow files** in `.github/workflows/`:

| Action | Before | After | Why |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | `@v4` runs on Node.js 20 (deprecated); `@v6` runs on Node.js 24 with no input changes for our usage. |
| `actions/cache/restore` | `@v4` | `@v5` | Same Node 20->24 reason; v5 keeps all v4 inputs. |
| `actions/cache/save` | `@v4` | `@v5` | Same as above. |
| `actions/upload-artifact` | `@v4` | `@v7` | v4 runs on Node 20. v7 is the lowest major shipping a Node 24 runtime with backwards-compatible inputs (`name`, `path`, `if-no-files-found`). |
| `actions/download-artifact` | *(new)* | `@v8` | Newly introduced in the `release` job; v8 is the lowest major on Node 24 and download-by-name behavior is unchanged from v4. |
| `docker/login-action` | `@v3` | `@v4` | `@v3` runs on Node.js 20 (runner emitted the deprecation warning); `@v4` runs on Node.js 24 with backwards-compatible `registry`/`username`/`password` inputs. |

GitHub runners are deprecating Node.js 20 for JavaScript-based actions
(default-flipped to Node 24 on **2026-06-16**, Node 20 removed on
**2026-09-16**). All bumps were picked to be the lowest major shipping
a Node 24 runtime while retaining backwards-compatible inputs for our
existing usage, so no other changes were required at the call sites.
After these bumps no JavaScript-based action referenced from any
workflow in this repository still runs on the deprecated Node.js 20
runtime.

## What did NOT change

- Build logic, build inputs, secrets, signing-key handling, the
  matrix, cache keys, the per-tag subcomponent path lists, and the
  contents of the produced binaries.
- The user-facing artifact / Release-asset filename
  (`<BUILD_DIR_NAME>_<tag>.zip` on tag-on-master builds,
  `<BUILD_DIR_NAME>` otherwise).
- The Actions-page "Download artifact" UX: clicking Download still
  yields a single zip whose top-level entry is the per-run directory.
- The "tag must be on master" gate for publishing a Release.
- Triggers, environment names, or matrix definitions of any workflow.

## Verification

- All 14 YAML files parse cleanly with `yaml.safe_load`.
- For each hardened firmware-build workflow (all six):
  - The `build` job exposes exactly two outputs (`release_zip_name`,
    `tag_on_master`) and uploads exactly one workflow artifact
    (the directory) with `if-no-files-found: error`.
  - The `release` job is gated on
    `startsWith(github.ref, 'refs/tags/') && needs.build.outputs.tag_on_master == 'true'`
    and declares only `{contents: write, actions: read}` permissions.
- A `grep -E 'uses: (actions/(checkout|cache/(restore|save)|upload-artifact|download-artifact)|docker/login-action)@'`
  across `.github/workflows/` returns only the bumped versions
  (no remaining `@v4` references for the `actions/*` items above, and
  no remaining `docker/login-action@v3` references).

## Test plan

1. **Pull-request build** (this PR): the `build` job should run with
   the default `GITHUB_TOKEN` scope and complete normally for each
   board; the `release` job should be skipped (`if:` evaluates to
   `false` on non-tag refs). Non-firmware workflows
   (`code-style.yml`, `unit-tests-*.yml`, `sonar-scan.yml`, etc.)
   should run with no Node.js 20 deprecation warnings in their logs.
2. **Branch push to `master`** (no tag): same as PR -- only `build`
   runs.
3. **Tag push not on `master`**: `build` job runs, `release` job is
   skipped (`tag_on_master == 'false'`).
4. **Tag push on `master`** (the new publishing path): `build` runs
   and uploads the per-run directory as a workflow artifact;
   `release` runs in parallel with the other firmware-build
   workflows, exactly one of them creates the GitHub Release, all
   six upload their respective board/env zip as Release assets
   without name collisions (including the
   `build_nrf52840dk_a2_release_mock-dev_<tag>.zip` mock asset);
   `gh release upload` is called with `--clobber` so retries are
   safe.
5. **Tag push with `/` in the name** (e.g. `release/v0.0.0-test`):
   filename and asset name should be
   `<BUILD_DIR_NAME>_release_v0.0.0-test.zip` (single path
   component, `_` instead of `/`).
6. **Manually break a `paths=( ... )` entry**: the build job should
   fail with `Missing release file: ...` on stderr instead of the
   generic `cp` error.

## Related

- Equivalent gateway change:
  [`ruuvi.gateway_esp.c#1281`](https://github.com/ruuvi/ruuvi.gateway_esp.c/issues/1281)
  (commits `09309fe9..19ef5162`).
